### PR TITLE
chore(.prettierignore): add *.yml file extension to the list of files…

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 static
 exmapleSite
 *.yaml
+*.yml


### PR DESCRIPTION
… ignored by Prettier to maintain consistent code formatting