### PR TITLE
fix: enhance accessibility with `tabIndex`

### DIFF
--- a/assets/ts/desktop/stageNav.tsx
+++ b/assets/ts/desktop/stageNav.tsx
@@ -83,6 +83,7 @@ export default function StageNav(props: {
               onKeyDown={handleKey}
               onFocus={() => props.setHoverText(item)}
               onMouseOver={() => props.setHoverText(item)}
+              tabIndex="-1"
             />
           )}
         </For>


### PR DESCRIPTION
- Add `tabIndex="-1"` to the navigation item for accessibility, fix #353 