### PR TITLE
docs: clarify relative path usage in documentation

### DIFF
--- a/doc/getStarted.md
+++ b/doc/getStarted.md
@@ -169,7 +169,7 @@ path = "github.com/Sped0n/bridget/v2"
 
 - If you have _installation with Git_
 
-  - `replacement`: replace the _path after the arrow_(`../..`) with the location of your local theme file (⚠️⚠️⚠️**relative path only**, example: `themes/bridget`)
+  - `replacement`: replace the _path after the arrow_(`../..`) with the location of your local theme file (⚠️⚠️⚠️**relative path to hugo site theme directory only([official doc](https://gohugo.io/hugo-modules/configuration/#module-configuration-top-level))**, example: `bridget`)
   - `path`: no change
 
 - If you have _installation with Module_, **remove the `replacements` configuration**.

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -22,6 +22,6 @@ defaultContentLanguage = 'en'
 
 # theme as module
 [module]
-replacements = "github.com/Sped0n/bridget/v2 -> ../.." # deploy with local dir  WARN: delete this line if you want to deploy with git
+replacements = "github.com/Sped0n/bridget/v2 -> ../.." # deploy with local dir (relative to hugo site theme dir)  WARN: delete this line if you want to deploy with git
 [[module.imports]]
 path = "github.com/Sped0n/bridget/v2" # deploy with git (recommended)  WARN: you should also set `bundled` to true in params.toml !!!


### PR DESCRIPTION
- Clarify the relative path requirement in the installation documentation
- Update the comment in the configuration file to specify the relative path context
- Close #378 